### PR TITLE
Arrumando aspas

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,1 +1,1 @@
-console.log("Rodando o sistema "de gerenciamento de jogos")
+console.log("Rodando o sistema de gerenciamento de jogos")


### PR DESCRIPTION
Não se pode utilizar aspas no meio de uma frase, pois a linguagem acha que você está tentando terminar a string.